### PR TITLE
Fix ClientThrottle.Stop() panicing from nil chan

### DIFF
--- a/ratelimit.go
+++ b/ratelimit.go
@@ -15,6 +15,7 @@ func NewThrottler() *ClientThrottle {
 	r := ClientThrottle{
 		c:       cache.NewLRUCache(maxHosts),
 		blocked: cache.NewLRUCache(maxHosts),
+		stop:    make(chan bool),
 	}
 	go r.cleanup()
 	return &r


### PR DESCRIPTION
Also, one concern I have with using close(chan) for this and the DHT's stop chan, is that:

It leaves the object in an inconsistent state, i.e. once it is stopped it cannot be restarted.

It doesn't block, and since there is no mechanism for knowing whether it is running or not, there is no way to confirm it has stopped.  Actions may be dependent on a successful Close().  The consolation is that Stop()'ing something that isn't running won't block.
